### PR TITLE
[#33] Add enableLowInitialPlaylist to videojs embed

### DIFF
--- a/filter.php
+++ b/filter.php
@@ -282,6 +282,9 @@ class filter_smartmedia extends moodle_text_filter {
         $matches = [];
 
         if (preg_match($pattern, $newtext, $matches)) {
+            // Note $matches[1] here is just what was matched.
+            // since it is the first parenthesized subpattern matched.
+            // see https://www.php.net/manual/en/function.preg-match.php.
             $originalvalue = $matches[1];
 
             $decoded = json_decode(htmlspecialchars_decode($originalvalue));


### PR DESCRIPTION
See https://github.com/catalyst/moodle-filter_smartmedia/issues/33 for issue details

- Moodle's videojs version reads from the `data-setup-lazy` property in the `<video/>` tag
- Unfortunately `core_media_player_native::get_attribute` does not work here since the `<video>` tag is not the highest tag (it is wrapped in a div)
- To avoid modifying moodle core, we just do a bit of regex and str_replace

Closes #33