### PR TITLE
[#36] Fix typo in previous patch

### DIFF
--- a/filter.php
+++ b/filter.php
@@ -516,7 +516,7 @@ class filter_smartmedia extends moodle_text_filter {
         }
 
         // Then check the course module has a URL, if so then use that instead.
-        if ($isajax && !empty($cm) && !empty($cm->get->url())) {
+        if ($isajax && !empty($cm) && !empty($cm->get_url())) {
             $url = $cm->get_url();
         }
 

--- a/tests/filter_test.php
+++ b/tests/filter_test.php
@@ -301,15 +301,6 @@ class filter_smartmedia_testcase extends advanced_testcase {
                 '/my/',
                 'system'
             ],
-            // Test <a>, Legit video link via webservice url in course context.
-            [
-                html_writer::link('url.com/pluginfile.php/fake.mp4', 'My Fake Video'),
-                '~<video~',
-                1,
-                1,
-                '/lib/ajax/service.php',
-                'course'
-            ],
             // Test <a>, Legit video link via webservice url in system context.
             [
                 html_writer::link('url.com/pluginfile.php/fake.mp4', 'My Fake Video'),
@@ -319,6 +310,15 @@ class filter_smartmedia_testcase extends advanced_testcase {
                 '/lib/ajax/service.php',
                 'system'
             ],
+            // Test <a>, Legit video link via webservice url in course context.
+            [
+                html_writer::link('url.com/pluginfile.php/fake.mp4', 'My Fake Video'),
+                '~<video~',
+                1,
+                1,
+                '/lib/ajax/service.php',
+                'course'
+            ],
             // Test <a>, Legit video link via webservice url in module context.
             [
                 html_writer::link('url.com/pluginfile.php/fake.mp4', 'My Fake Video'),
@@ -326,7 +326,16 @@ class filter_smartmedia_testcase extends advanced_testcase {
                 1,
                 1,
                 '/lib/ajax/service.php',
-                'system'
+                'module'
+            ],
+            // Test <a>, Legit video link via webservice url in course context.
+            [
+                html_writer::link('url.com/pluginfile.php/fake.mp4', 'My Fake Video'),
+                '~<video~',
+                1,
+                1,
+                '/lib/ajax/service.php',
+                'course'
             ],
             // Test <a>, Legit video link via course url.
             [
@@ -343,7 +352,7 @@ class filter_smartmedia_testcase extends advanced_testcase {
                 '~<video~',
                 1,
                 1,
-                '/mod/label/view.php?id=:cmid',
+                '/mod/forum/view.php?id=:cmid',
                 'module'
             ],
             // Test <a>, Not supported extension.
@@ -464,7 +473,7 @@ class filter_smartmedia_testcase extends advanced_testcase {
 
         $this->resetAfterTest();
         $course = $this->getDataGenerator()->create_course(['hiddensections' => 0, 'coursedisplay' => COURSE_DISPLAY_SINGLEPAGE]);
-        $module = $this->getDataGenerator()->create_module('label', ['course' => $course->id]);
+        $module = $this->getDataGenerator()->create_module('forum', ['course' => $course->id]);
 
         // Replace courseid placeholder in pageurl.
         if (strpos($pageurl, ':courseid') !== false) {
@@ -494,7 +503,7 @@ class filter_smartmedia_testcase extends advanced_testcase {
             ],
             'data' => [],
             'download' => [],
-            'context' => \context::instance_by_id(1)
+            'context' => $PAGE->context
         ]);
         $PAGE->set_url(new moodle_url($pageurl));
 


### PR DESCRIPTION
After looking at https://github.com/catalyst/moodle-filter_smartmedia/pull/37 again I noticed:

https://github.com/catalyst/moodle-filter_smartmedia/pull/37/files#diff-7e65ffe11d9b1dec1ce0329e2917c0782e7ac4a2b3c1dc6dfe995088fe66f763R519

Has `$cm->get->url` where it should be `$cm->get_url()`

I discovered this code path never actually was tested, so I have changed the tests slightly so it is hit (and threw error as expected):

```
...........Debugging: Invalid cm_info property accessed: get
* line 1239 of /lib/modinfolib.php: call to debugging()
* line 519 of /filter/smartmedia/filter.php: call to cm_info->__get()
* line 400 of /filter/smartmedia/filter.php: call to filter_smartmedia->url_from_context()
* line 677 of /filter/smartmedia/filter.php: call to filter_smartmedia->replace()
* line 530 of /filter/smartmedia/tests/filter_test.php: call to filter_smartmedia->filter()
* line 1154 of /vendor/phpunit/phpunit/src/Framework/TestCase.php: call to filter_smartmedia_testcase->test_filter_replace()
* line 842 of /vendor/phpunit/phpunit/src/Framework/TestCase.php: call to PHPUnit\Framework\TestCase->runTest()
* line 80 of /lib/phpunit/classes/advanced_testcase.php: call to PHPUnit\Framework\TestCase->runBare()
* line 693 of /vendor/phpunit/phpunit/src/Framework/TestResult.php: call to advanced_testcase->runBare()
* line 796 of /vendor/phpunit/phpunit/src/Framework/TestCase.php: call to PHPUnit\Framework\TestResult->run()
* line 746 of /vendor/phpunit/phpunit/src/Framework/TestSuite.php: call to PHPUnit\Framework\TestCase->run()
* line 746 of /vendor/phpunit/phpunit/src/Framework/TestSuite.php: call to PHPUnit\Framework\TestSuite->run()
* line 652 of /vendor/phpunit/phpunit/src/TextUI/TestRunner.php: call to PHPUnit\Framework\TestSuite->run()
* line 206 of /vendor/phpunit/phpunit/src/TextUI/Command.php: call to PHPUnit\TextUI\TestRunner->doRun()
* line 162 of /vendor/phpunit/phpunit/src/TextUI/Command.php: call to PHPUnit\TextUI\Command->run()
* line 60 of phpvfscomposer:///vendor/phpunit/phpunit/phpunit: call to PHPUnit\TextUI\Command::main()
* line 118 of /vendor/bin/phpunit: call to include()
```

The changes to the tests are:

- Switching `mod_label` -> `mod_forum` since `mod_label` doesn't have a `$cm->get_url` (so code path will never be reached)
- Added all three contexts (system course and module) via webservice. Previously was only system (causing code path to never be reached).
- Passing the context from the page to the smartmedia conversion.

And of course now I have fixed the typo, these tests pass :tada: 