### PR TITLE
fix: Fix encoding change from 4.5 compat changes

### DIFF
--- a/classes/text_filter.php
+++ b/classes/text_filter.php
@@ -585,7 +585,7 @@ class text_filter extends \core_filters\text_filter {
         // Add a wrapping div so DOMDocument doesnt mangle the structure.
         $loadtext = '<div>' . $text . '</div>';
         // Ensure the encoding can be loaded by the domdoc.
-        $loadtext = html_entity_decode($loadtext);
+        $loadtext = mb_encode_numericentity($loadtext, [0xa0, 0xffff, 0, 0xffff], 'UTF-8', true);
 
         // Supress warnings. HTML5 nodes currently throw warnings.
         // Use flags to prevent html and body tags from being included.
@@ -618,7 +618,7 @@ class text_filter extends \core_filters\text_filter {
             // Encase in another div to prevent mangling when loading into the new domdoc.
             $newtext = '<div>' . $newtext . '</div>';
             // Encode to the domdocument usable format.
-            $newtext = html_entity_decode($newtext);
+            $newtext = mb_encode_numericentity($newtext, [0xa0, 0xffff, 0, 0xffff], 'UTF-8', true);
 
             // Open that as a new doc to pull the video node out.
             $tempdom = new DOMDocument('1.0', 'UTF-8');
@@ -688,7 +688,7 @@ class text_filter extends \core_filters\text_filter {
             // Encase in another div to prevent mangling when loading into the new domdoc.
             $newtext = '<div>' . $newtext . '</div>';
             // Encode to the domdocument usable format.
-            $newtext = html_entity_decode($newtext);
+            $newtext = mb_encode_numericentity($newtext, [0xa0, 0xffff, 0, 0xffff], 'UTF-8', true);
 
             // Open that as a new doc to pull the video node out.
             $tempdom = new DOMDocument('1.0', 'UTF-8');


### PR DESCRIPTION
This corrects the encoding change made in commit  https://github.com/catalyst/moodle-filter_smartmedia/commit/dd7d044d0030db64470011d2a85c0be09e28c826

I've used what core has done in `core_text::utf8_to_entities` minus the `mb_strtolower`.