### PR TITLE
[#54] Fix failing unit tests

### DIFF
--- a/tests/filter_test.php
+++ b/tests/filter_test.php
@@ -580,7 +580,7 @@ final class filter_test extends advanced_testcase {
         $this->resetDebugging();
         $text = '<div><div><video><source src="url.com/pluginfile.php/fake.mp4"/></video></div></div>';
         $result = $filterplugin->filter($text);
-        $this->assertMatchesRegularExpression('/<button.*View source media.*<\/button>/', $result);
+        $this->assertMatchesRegularExpression('/<a.*View source media.*<\/a>/', $result);
     }
 
     public function test_view_optimised(): void {
@@ -605,6 +605,6 @@ final class filter_test extends advanced_testcase {
         $filterplugin = new text_filter(null, [], $conversion);
         $this->resetDebugging();
         $result = $filterplugin->filter($text);
-        $this->assertMatchesRegularExpression('/<button.*View optimised media.*<\/button>/', $result);
+        $this->assertMatchesRegularExpression('/<a.*View optimised media.*<\/a>/', $result);
     }
 }


### PR DESCRIPTION
Swap out `<button>` for `<a>` in test_view_optimised & test_view_source

```
root@41694de31337:/var/www/site# vendor/bin/phpunit filter/smartmedia/tests/filter_test.php
Moodle 4.5.8+ (Build: 20251219), 19e73158eb92d5eead47c984e04a10ab79c84ba2
Php: 8.3.25, pgsql: 17.4 (Debian 17.4-1.pgdg120+2), OS: Linux 6.14.0-37-generic x86_64
PHPUnit 9.6.18 by Sebastian Bergmann and contributors.

..............................                                    30 / 30 (100%)

Time: 00:07.021, Memory: 109.00 MB

OK (30 tests, 83 assertions)
```